### PR TITLE
Remove `hasPart` references to `ItemList`

### DIFF
--- a/lib/Schema/ItemList.php
+++ b/lib/Schema/ItemList.php
@@ -66,22 +66,12 @@ final class ItemList {
                     '@id' => $context->canonical . '#/schema/itemlist/' . sanitize_title( $list_name ),
                 ];
             }
-            
-            $list_as_side_content = ['ProfilePage', 'AboutPage', 'ItemPage'];
-            $webpage_type = (array) $webpage_data['@type'];
-            if ( ! empty( array_intersect( $webpage_type, $list_as_side_content ) ) ) {
-                $webpage_data['mentions'] = $webpage_data['mentions'] ?? [];
-                array_push(
-                    $webpage_data['mentions'],
-                    ...$references,
-                );
-            } else {
-                $webpage_data['hasPart'] = $webpage_data['hasPart'] ?? [];
-                array_push(
-                    $webpage_data['hasPart'],
-                    ...$references,
-                );
-            }
+
+            $webpage_data['mentions'] ??= [];
+            array_push(
+                $webpage_data['mentions'],
+                ...$references,
+            );
             
             return $webpage_data;
         }, 10, 2 );

--- a/tests/Query_Loop_Schema_Test.php
+++ b/tests/Query_Loop_Schema_Test.php
@@ -67,10 +67,10 @@ final class Query_Loop_Schema_Test extends \WP_UnitTestCase {
 		$webpage = $this->find_node_by_type( $graph, 'CollectionPage' );
 		$this->assertNotNull( $webpage, 'Should have CollectionPage node' );
 
-		// Assert WebPage has hasPart property.
-		$this->assertArrayHasKey( 'hasPart', $webpage, 'WebPage should have hasPart property' );
-		$this->assertIsArray( $webpage['hasPart'], 'hasPart should be an array' );
-		$this->assertCount( 1, $webpage['hasPart'], 'hasPart should reference 1 ItemList' );
+		// Assert WebPage has mentions property.
+		$this->assertArrayHasKey( 'mentions', $webpage, 'WebPage should have hasPart property' );
+		$this->assertIsArray( $webpage['mentions'], 'hasPart should be an array' );
+		$this->assertCount( 1, $webpage['mentions'], 'hasPart should reference 1 ItemList' );
 
 		// Find ItemList node.
 		$item_list = $this->find_node_by_type( $graph, 'ItemList' );
@@ -90,13 +90,13 @@ final class Query_Loop_Schema_Test extends \WP_UnitTestCase {
 
 			// Verify @id points to article fragment.
 			$expected_post = $this->post_ids[ count( $this->post_ids ) - $index - 1 ];
-			$expected_url = get_permalink( $expected_post );// . '#article';
+			$expected_url = get_permalink( $expected_post );
 			$this->assertSame( $expected_url, $list_item['item']['@id'], 'Should reference article @id' );
 		}
 
 		// Verify WebPage references ItemList.
 		$list_id = $item_list['@id'];
-		$this->assertSame( $list_id, $webpage['hasPart'][0]['@id'], 'WebPage should reference ItemList @id' );
+		$this->assertSame( $list_id, $webpage['mentions'][0]['@id'], 'WebPage should reference ItemList @id' );
 	}
 
 	/**
@@ -190,7 +190,7 @@ final class Query_Loop_Schema_Test extends \WP_UnitTestCase {
 
 		// Verify WebPage references both.
 		$webpage = $this->find_node_by_type( $graph, 'WebPage' );
-		$this->assertCount( 2, $webpage['hasPart'] ?? [], 'WebPage should reference 2 ItemLists' );
+		$this->assertCount( 2, $webpage['mentions'] ?? [], 'WebPage should reference 2 ItemLists' );
 	}
 
 	/**


### PR DESCRIPTION
hasPart exists on a Creative Work, referring to another Creative Work. Since the ItemList is not a Creative Work, it does not fit the schema. Unless we find a suitable hybrid type to enhance with, but for now, step back to allow leaping forward.